### PR TITLE
Bump glob and mocha to fix minimatch DDOS issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "async": "^0.9.0",
     "chai": "^1.10.0",
     "combined-stream": "0.0.7",
-    "glob": "^4.3.2",
+    "glob": "^7.1.1",
     "htmlmin": "0.0.4",
     "jade": "^1.8.2",
     "through2": "^0.6.3"
   },
   "devDependencies": {
-    "mocha": "^2.1.0"
+    "mocha": "^3.2.0"
   },
   "scripts": {
     "test": "mocha test/**.spec.js"


### PR DESCRIPTION
When installing `npm-html2js` you get these errors:

```
warning npm-html2js > glob > minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning npm-html2js > jade@1.11.0: Jade has been renamed to pug, please install the latest version of pug instead of jade
warning npm-html2js > jade > transformers@2.1.0: Deprecated, use jstransformer
```

This PR fixes the `minimatch` issue. I was also going to try to tackle the pug warning, but they don't appear to have a stable version yet (and they didn't publish previous versions).